### PR TITLE
Don't render app index when redirecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "leptos-fluent",
  "leptos-use",
  "leptos_icons",
+ "leptos_meta",
  "rand",
  "simple-icons-macros",
  "simple-icons-website-ids",

--- a/app/src/head.rs
+++ b/app/src/head.rs
@@ -1,7 +1,7 @@
 use crate::app::TITLE;
 use leptos::prelude::*;
 use leptos_fluent::tr;
-use leptos_meta::*;
+use leptos_meta::{provide_meta_context, Link, Meta, Title};
 use simple_icons_macros::get_number_of_icons;
 
 static DOMAIN: &str = "simpleicons.org";

--- a/app/src/pages.rs
+++ b/app/src/pages.rs
@@ -22,7 +22,7 @@ use simple_icons_website_components::{
 };
 use simple_icons_website_preview_generator::PreviewGenerator;
 
-fn index_redirections() {
+fn index_redirections() -> bool {
     let query_map = use_query_map().get_untracked();
 
     // Trick to redirect to other pages for servers that don't support SPAs
@@ -39,12 +39,21 @@ fn index_redirections() {
         #[cfg(debug_assertions)]
         ::leptos::logging::log!("Redirecting to {}", url);
         use_navigate()(&url, navigate_opts);
+
+        return true;
     }
+
+    false
 }
 
 #[component]
-pub fn Index() -> impl IntoView {
-    index_redirections();
+pub fn Index() -> AnyView {
+    let redirected = index_redirections();
+
+    if redirected {
+        #[allow(clippy::unit_arg, clippy::unused_unit)]
+        return view!().into_any();
+    }
 
     let icons = expect_context::<IconsIndexSignal>().0;
     let initial_search_value = provide_search_context(icons.clone());
@@ -63,6 +72,7 @@ pub fn Index() -> impl IntoView {
         <Controls />
         <Grid />
     }
+    .into_any()
 }
 
 #[component]

--- a/components/Cargo.toml
+++ b/components/Cargo.toml
@@ -19,6 +19,7 @@ simple-icons-website-url.workspace = true
 web-sys-simple-events.workspace = true
 web-sys-simple-fetch.workspace = true
 leptos.workspace = true
+leptos_meta.workspace = true
 leptos-use.workspace = true
 leptos-fluent.workspace = true
 leptos_icons.workspace = true

--- a/components/src/grid/ad.rs
+++ b/components/src/grid/ad.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_meta::Link;
 
 /// Carbon ads add grid item
 ///
@@ -6,7 +7,7 @@ use leptos::prelude::*;
 #[component]
 pub fn CarbonAdsAdGridItem() -> impl IntoView {
     view! {
-        <style>r#".layout-compact #carbonads { grid-row: -3/-1; padding-top: 15%; }"#</style>
+        <Link rel="preconnect" href="https://cdn.carbonads.com" />
         <script
             id="_carbonads_js"
             async

--- a/components/src/grid/item/mod.css
+++ b/components/src/grid/item/mod.css
@@ -25,6 +25,11 @@ main > ul > li,
   text-align: center;
 }
 
+.layout-compact #carbonads {
+  grid-row: -3/-1;
+  padding-top: 15%;
+}
+
 @media (width <= 1280px) {
   .layout-compact #carbonads {
     grid-column: -3 / -1;


### PR DESCRIPTION
The ad is tried to be created at preview generator, which shows the next error on console:

```
Uncaught TypeError: Cannot read properties of null (reading 'src')
    at Object.getUrlVar (carbon.js?serve=CKYIPK7M&placement=simpleiconsorg:1:13777)
    at Object.init (carbon.js?serve=CKYIPK7M&placement=simpleiconsorg:1:6882)
    at carbon.js?serve=CKYIPK7M&placement=simpleiconsorg:1:37556
```

Because the whole grid is created at index even when redirecting to relative pages.