### PR TITLE
Fix icon modal not opened using `modal=icon` in URL

### DIFF
--- a/components/src/grid/mod.rs
+++ b/components/src/grid/mod.rs
@@ -123,7 +123,7 @@ fn initial_icons_from_search_value_order_mode_and_layout(
 fn wait_for_first_grid_item_and_open_details(attempt: u32) {
     if let Some(el) = document()
         .query_selector(
-            "main > ul > :first-child > :last-child > :nth-child(2)",
+            "main > ul > :nth-child(3) > :last-child > :nth-child(2)",
         )
         .unwrap_or(None)
     {

--- a/components/src/grid/mod.rs
+++ b/components/src/grid/mod.rs
@@ -123,7 +123,7 @@ fn initial_icons_from_search_value_order_mode_and_layout(
 fn wait_for_first_grid_item_and_open_details(attempt: u32) {
     if let Some(el) = document()
         .query_selector(
-            "main > ul > :nth-child(3) > :last-child > :nth-child(2)",
+            "main > ul > :nth-child(2) > :last-child > :nth-child(2)",
         )
         .unwrap_or(None)
     {


### PR DESCRIPTION
Regression from #268