### PR TITLE
Copy preview if no text is selected on preview generator

### DIFF
--- a/components/preview-generator/src/keyboard.rs
+++ b/components/preview-generator/src/keyboard.rs
@@ -49,10 +49,17 @@ pub(crate) fn listen_keyboard_shortcuts() {
                     .contains(&previous_code.as_str())
             {
                 // Ctrl + C
-                if let Ok(Some(_)) = window().get_selection() {
+                let click_preview_copy_button =
+                    || click_button(Ids::PreviewCopyButton.as_str());
+                if let Ok(Some(selection)) = window().get_selection() {
                     // don't copy the view because there is some text selected
+                    if selection.type_() != "Range" {
+                        click_preview_copy_button();
+                        event.prevent_default();
+                    }
                 } else {
-                    click_button(Ids::PreviewCopyButton.as_str());
+                    click_preview_copy_button();
+                    event.prevent_default();
                 }
             } else if code == "keys"
                 && ["controlleft", "controlright"]


### PR DESCRIPTION
Previously, if some text was selected, pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> the text was not copied, but the preview instead. Now, if there is some text selected copy the text, otherwise the preview.

It isn't related to #363, I just realized now reviewing the code.