### PR TITLE
Fix Rust formatting configuration inconsistencies

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           components: clippy
+          cache-key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.task }}
       - name: Install tooling dependencies
         uses: taiki-e/install-action@v2
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,10 @@
 		"editor.tabSize": 4,
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
+	"[rust]": {
+		"editor.tabSize": 4,
+		"editor.defaultFormatter": "rust-lang.rust-analyzer"
+	},
 
 	// TailwindCSS IntelliSense
 	"tailwindCSS.includeLanguages": {
@@ -83,5 +87,10 @@
 		"--all-targets",
 		"--message-format=json"
 	],
-	"rust-analyzer.rustfmt.overrideCommand": ["leptosfmt", "--stdin", "--rustfmt"]
+	"rust-analyzer.rustfmt.overrideCommand": [
+		"leptosfmt",
+		"--stdin",
+		"--rustfmt",
+		"--rustfmt-args=--edition=2024"
+	]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,12 @@
 
 - Install Rust with [rustup](https://rustup.rs/).
 - Install [cargo-make] with `cargo install --force cargo-make`.
-- Install [fnm](https://github.com/Schniz/fnm) with `cargo install fnm` and [setup your Shell](https://github.com/Schniz/fnm#shell-setup).
 - Install NodeJS with npm and run `npm install`.
 - Create an _.env_ file at the root including a Github personal token with the variable `GITHUB_TOKEN` like `GITHUB_TOKEN=...`.
 
 ## Commands
 
-- `cargo make`: Build WASM and serve. With `watch-css`, recommended for development. After it, you can use `cd app && trunk serve` to serve.
+- `cargo make`: Build WASM and serve for development. This does not watch CSS files (see `watch-css` below).
 - `cargo make watch-css`: Watch the CSS files with [TailwindCSS](https://tailwindcss.com/).
 - `cargo make format`: Format files.
 - `cargo make lint`: Check formatting of files.
@@ -20,7 +19,7 @@
 
 ## Testing
 
-To run end-to-end tests execute in three different terminals:
+To run end-to-end tests, execute in three different terminals:
 
 ```sh
 chromedriver --port=4444
@@ -68,7 +67,7 @@ Note that different screen sizes must be located in different test suites.
 
 ### Where to look
 
-- End to end tests are located in _end2end/tests/_. They are written with [Playwright](https://playwright.dev/). Configuration is located at _end2end/playwright.config.ts_.
+- End to end tests are located in _end2end/tests/_.
 - The main stylesheet is located at _app/stylesheet.css_ other assets are located at _app/assets/_. Hopefully you don't need to change this style due to the class-based approach of TailwindCSS framework. Configuration is located at _app/tailwind.config.ts_.
 - The initial HTML is located at _app/index.html_. It is used by Trunk to generate the distributed HTML. Most frontend assets are located at _app/public/_.
 - The file _Makefile.toml_ contains the commands to build, test, format, lint and serve the website. It is used by [cargo-make].

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -152,7 +152,7 @@ args = ["dylint", "--all"]
 
 [tasks.leptosfmt-check]
 description = "Check Leptos code format with leptosfmt"
-install_crate = "leptosfmt"
+dependencies = ["install-leptosfmt"]
 command = "leptosfmt"
 args = ["--check", "--quiet", "**/src/**/*.rs"]
 
@@ -184,15 +184,21 @@ description = "Lint files in the project with Prettier"
 command = "npx"
 args = ["prettier", "--check", ".", "--log-level", "warn"]
 
+[tasks.cargo-fmt]
+description = "Format Rust code with cargo fmt"
+install_crate = "cargo-fmt"
+command = "cargo"
+args = ["fmt", "--all", "--quiet"]
+
 [tasks.leptosfmt]
 description = "Format leptos view! macros"
-install_crate = "leptosfmt"
+dependencies = ["install-leptosfmt"]
 command = "leptosfmt"
 args = ["--quiet", "**/src/**/*.rs"]
 
 [tasks.format-rust]
 description = "Format Rust code"
-run_task = { name = ["leptosfmt"] }
+run_task = { name = ["cargo-fmt", "leptosfmt"] }
 
 [tasks.prettier-write]
 description = "Format files in the project with Prettier"
@@ -277,3 +283,13 @@ run_task = { name = [
 	"fetch-deprecated-icons",
 	"create-sitemap",
 ], parallel = true }
+
+[tasks.install-leptosfmt]
+# Using the latest version of leptosfmt from GitHub, because released versions
+# don't include support for passing arguments to `rustfmt`, which is needed to
+# format files with Rust features like async functions.
+description = "Install leptosfmt from Git if not already installed"
+script_runner = "bash"
+script = '''
+which leptosfmt > /dev/null || cargo install --git https://github.com/bram209/leptosfmt
+'''

--- a/app/src/pages.rs
+++ b/app/src/pages.rs
@@ -56,7 +56,7 @@ pub fn Index() -> AnyView {
 
     if redirected {
         #[allow(clippy::unit_arg, clippy::unused_unit)]
-        return view!().into_any();
+        return view! {  }.into_any();
     }
 
     let icons = expect_context::<IconsIndexSignal>().0;

--- a/components/controls/src/order.rs
+++ b/components/controls/src/order.rs
@@ -234,7 +234,7 @@ pub fn OrderControl() -> impl IntoView {
                 />
                 {move || match search_signal().is_empty() {
                     #[allow(clippy::unit_arg, clippy::unused_unit)]
-                    true => view!().into_any(),
+                    true => view! {  }.into_any(),
                     false => {
                         view! {
                             <ControlButtonIcon

--- a/components/grid/src/item/footer.rs
+++ b/components/grid/src/item/footer.rs
@@ -1,11 +1,11 @@
 use crate::{
-    item::details::fill_icon_details_modal_with_icon, CurrentIconViewSignal,
+    CurrentIconViewSignal, item::details::fill_icon_details_modal_with_icon,
 };
 use leptos::ev::MouseEvent;
 use leptos::prelude::*;
-use leptos_fluent::{move_tr, tr, I18n};
+use leptos_fluent::{I18n, move_tr, tr};
 use simple_icons_website_controls::download::{
-    download_png, download_svg, DownloadType, DownloadTypeSignal,
+    DownloadType, DownloadTypeSignal, download_png, download_svg,
 };
 use simple_icons_website_controls_search::focus_search_bar;
 use simple_icons_website_copy::copy_and_set_copied_transition;

--- a/components/header/src/nav/language_selector.rs
+++ b/components/header/src/nav/language_selector.rs
@@ -1,7 +1,7 @@
-use crate::{nav::button::HeaderMenuButton, HeaderStateSignal};
+use crate::{HeaderStateSignal, nav::button::HeaderMenuButton};
 use icondata::IoLanguageSharp;
 use leptos::prelude::*;
-use leptos_fluent::{move_tr, I18n, Language};
+use leptos_fluent::{I18n, Language, move_tr};
 use simple_icons_website_modal::{Modal, ModalOpen, ModalOpenSignal};
 
 fn render_language(lang: &'static Language) -> impl IntoView {

--- a/components/menu/src/lib.rs
+++ b/components/menu/src/lib.rs
@@ -39,12 +39,12 @@ pub fn MenuItem(
                         .into_any()
                 }
                 #[allow(clippy::unit_arg, clippy::unused_unit)]
-                None => view!().into_any(),
+                None => view! {  }.into_any(),
             }} {text}
             {match children {
                 Some(child) => child().into_any(),
                 #[allow(clippy::unit_arg, clippy::unused_unit)]
-                None => view!().into_any(),
+                None => view! {  }.into_any(),
             }}
         </li>
     }


### PR DESCRIPTION
Leptos formatting is still a pain:

- `leptosfmt` only calls `rustfmt` when using `--stdin` with `--rustfmt` (`--rustfmt` requires `--stdin`). This is needed by Rust Analyzer.
- `leptosfmt` does not include in their latest released crate the argument `--rustfmt-args`, which is required by Rust Analyzer to format files with `async` and other stable stuff or will fail silently in RA. So must be installed from the GIT repository.
- In `format` task, additionally `cargo fmt` must be executed but before `leptosfmt`. This is not the same as calling after, like `leptosfmt --stdin --rustfmt` with RA does, but it is OK as RA is not part of the final workflow (and it seems to me that rustfmt does not rewrite imports?).
- In `lint` task, only `leptosfmt` because `cargo fmt` complains about the formatting applied by `leptosfmt` to imports.