### PR TITLE
Add Rust Apps Lints library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ opt-level = 'z'
 libraries = [
 	{ git = "https://github.com/leptos-rs/leptos-lints", tag = "v0.1.0" },
 	{ git = "https://github.com/mondeja/leptos-unique-ids", tag = "v0.1.0", pattern = "lints" },
+	{ git = "https://github.com/mondeja/rs-apps-lints", tag = "v0.1.1", pattern = "lints/*" },
 ]
 
 [workspace.lints.clippy]
@@ -72,6 +73,13 @@ leptos_print_stdout = "deny"
 # Configuration for leptos-unique-ids lints
 literal_as_id_attribute_value = "deny"
 tt_as_id_attribute_value = "deny"
+# Configuration for rs-apps-lints
+#   web-sys
+#     this is triggering a warning with clippy,
+#     see https://github.com/rust-lang/rust-clippy/issues/15126
+web_sys_reexports = "deny"
+#   leptos
+leptos_reexports = "deny"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "deny"

--- a/components/grid/src/item/details.rs
+++ b/components/grid/src/item/details.rs
@@ -4,9 +4,7 @@ use icondata::{
     BsWindowFullscreen, IoColorWand, TbJpgOutline, TbPdfOutline, TbPngOutline,
     TbSvgOutline, VsSymbolNamespace,
 };
-use leptos::{
-    ev::MouseEvent, prelude::*, task::spawn_local, wasm_bindgen::JsCast,
-};
+use leptos::{ev::MouseEvent, prelude::*, task::spawn_local};
 use leptos_fluent::{I18n, move_tr, tr};
 use leptos_icons::Icon;
 use leptos_use::{UseClipboardReturn, on_click_outside, use_clipboard};
@@ -22,6 +20,7 @@ use simple_icons_website_ids::Ids;
 use simple_icons_website_menu::{Menu, MenuItem};
 use simple_icons_website_modal::{Modal, ModalOpenSignal};
 use simple_icons_website_types::SimpleIcon;
+use wasm_bindgen::JsCast;
 use web_sys_simple_fetch::fetch_text;
 
 fn get_brand_name_from_modal_container() -> String {

--- a/components/preview-generator/src/buttons.rs
+++ b/components/preview-generator/src/buttons.rs
@@ -1,5 +1,5 @@
 use crate::{canvas::canvas as canvas_container, helpers::is_valid_hex_color};
-use leptos::{prelude::*, task::spawn_local, wasm_bindgen::JsCast};
+use leptos::{prelude::*, task::spawn_local};
 use leptos_fluent::{move_tr, tr};
 use simple_icons_sdk as sdk;
 use simple_icons_website_controls::download::download;
@@ -7,6 +7,7 @@ use simple_icons_website_grid_constants::ICONS;
 use simple_icons_website_ids::Ids;
 use simple_icons_website_svg_defs::SVGDef;
 use simple_icons_website_svg_icon::{SVGIcon, svg_with_title_path_opt_fill};
+use wasm_bindgen::JsCast;
 use web_sys_simple_copy::copy_canvas_container_as_image;
 
 #[component]

--- a/components/preview-generator/src/canvas.rs
+++ b/components/preview-generator/src/canvas.rs
@@ -1,7 +1,5 @@
-use leptos::{
-    prelude::*,
-    wasm_bindgen::{JsCast, closure::Closure},
-};
+use leptos::prelude::*;
+use wasm_bindgen::{JsCast, closure::Closure};
 
 pub(crate) static WIDTH: u32 = 740;
 pub(crate) static HEIGHT: u32 = 490;


### PR DESCRIPTION
Configure a new lints library to force rewrites of current usages of the re-exported `wasm-bindgen` from `leptos` and prevent other usages of re-exports from `web-sys` and `leptos`.