### PR TITLE
Get icons `slug` from data file on build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,9 @@ literal_as_id_attribute_value = "deny"
 tt_as_id_attribute_value = "deny"
 # Configuration for rs-apps-lints
 #   web-sys
-#     this is triggering a warning with clippy,
+#     TODO: this is triggering a warning with the Rust compiler,
 #     see https://github.com/rust-lang/rust-clippy/issues/15126
-web_sys_reexports = "deny"
+#web_sys_reexports = "deny"
 #   leptos
 leptos_reexports = "deny"
 

--- a/libs/simple-icons-sdk/src/data.rs
+++ b/libs/simple-icons-sdk/src/data.rs
@@ -37,7 +37,7 @@ pub struct SimpleIconDataAliases {
 
 #[derive(DeJson)]
 pub struct SimpleIconData {
-    pub slug: Option<String>,
+    pub slug: String,
     pub title: String,
     pub hex: String,
     pub source: String,

--- a/libs/simple-icons/src/lib.rs
+++ b/libs/simple-icons/src/lib.rs
@@ -5,7 +5,6 @@ pub mod lint;
 pub use deprecated::{IconDeprecation, fetch_deprecated_simple_icons};
 use simple_icons_sdk::{
     SimpleIconDataAliases, SimpleIconDataLicense, get_simple_icons_data,
-    title_to_slug,
 };
 use std::fs;
 use std::path::Path;
@@ -31,10 +30,7 @@ pub fn get_simple_icons() -> Vec<SimpleIcon> {
 
     for icon_data in simple_icons_data {
         let icon = SimpleIcon {
-            slug: match icon_data.slug {
-                Some(slug) => slug,
-                None => title_to_slug(&icon_data.title),
-            },
+            slug: icon_data.slug,
             title: icon_data.title,
             hex: icon_data.hex,
             source: icon_data.source,


### PR DESCRIPTION
https://github.com/simple-icons/simple-icons/pull/13677 added the `slug` field to distributed data file.

Also, disable a lint that is false positive triggering warnings due to a bug in rustc.