### PR TITLE
Decouple `Waiter` for custom expected conditions of Thirtyfour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "cucumber-thirtyfour-worlder",
  "serde_json",
  "thirtyfour",
+ "tokio",
 ]
 
 [[package]]

--- a/tests/end2end-helpers/Cargo.toml
+++ b/tests/end2end-helpers/Cargo.toml
@@ -12,6 +12,7 @@ thirtyfour.workspace = true
 serde_json.workspace = true
 cucumber-thirtyfour-worlder.workspace = true
 async-trait = "0.1"
+tokio = { version = "1.30", features = ["time"] }
 
 [lints]
 workspace = true

--- a/tests/end2end-helpers/src/steps.rs
+++ b/tests/end2end-helpers/src/steps.rs
@@ -34,13 +34,7 @@ async fn check_file_is_downloaded(
 
     let condition = move || {
         let file_path = file_path.clone();
-        async move {
-            Ok(file_path.exists()).map_err(|e| {
-                thirtyfour::error::WebDriverError::UnknownError(
-                    thirtyfour::error::WebDriverErrorInfo::new(e.to_string()),
-                )
-            })
-        }
+        async move { Ok(file_path.exists()) }
     };
 
     Waiter::new(timeout, interval, message)


### PR DESCRIPTION
Decouples the `Waiter` struct used for Selenium custom conditions from Thirtyfour, so it can be used directly with tokio and anyhow.