### PR TITLE
Allow preview build without GITHUB_TOKEN

### DIFF
--- a/libs/simple-icons/src/deprecated.rs
+++ b/libs/simple-icons/src/deprecated.rs
@@ -28,7 +28,7 @@ impl PartialEq for IconDeprecation {
     }
 }
 
-fn is_preview_only_build() -> bool {
+fn can_use_empty_deprecated_icons() -> bool {
     let Ok(apps) = env::var("APPS") else {
         return false;
     };
@@ -39,7 +39,8 @@ fn is_preview_only_build() -> bool {
         .filter(|app| !app.is_empty())
         .collect::<Vec<_>>();
 
-    !apps.is_empty() && apps.iter().all(|app| *app == "preview")
+    !apps.is_empty()
+        && apps.iter().all(|app| *app == "preview" || *app == "404")
 }
 
 /**
@@ -49,7 +50,7 @@ fn is_preview_only_build() -> bool {
 pub fn fetch_deprecated_simple_icons() -> Vec<IconDeprecation> {
     let tmp_file_name = "simple-icons-deprecated.json";
     let tmp_file_path = Path::new(&env::temp_dir()).join(tmp_file_name);
-    if !tmp_file_path.exists() && is_preview_only_build() {
+    if !tmp_file_path.exists() && can_use_empty_deprecated_icons() {
         return Vec::new();
     }
 
@@ -69,10 +70,11 @@ pub fn fetch_deprecated_simple_icons() -> Vec<IconDeprecation> {
     }
 
     if resp
-        .get("previewOnly")
+        .get("emptyDeprecatedIcons")
+        .or_else(|| resp.get("previewOnly"))
         .and_then(serde_json::Value::as_bool)
         .unwrap_or_default()
-        && !is_preview_only_build()
+        && !can_use_empty_deprecated_icons()
     {
         fs::remove_file(&tmp_file_path).unwrap();
         panic!(

--- a/libs/simple-icons/src/deprecated.rs
+++ b/libs/simple-icons/src/deprecated.rs
@@ -28,6 +28,20 @@ impl PartialEq for IconDeprecation {
     }
 }
 
+fn is_preview_only_build() -> bool {
+    let Ok(apps) = env::var("APPS") else {
+        return false;
+    };
+
+    let apps = apps
+        .split(',')
+        .map(str::trim)
+        .filter(|app| !app.is_empty())
+        .collect::<Vec<_>>();
+
+    !apps.is_empty() && apps.iter().all(|app| *app == "preview")
+}
+
 /**
  * Get all the icons that will be removed in the next major versions
  * ordered by version.
@@ -35,6 +49,10 @@ impl PartialEq for IconDeprecation {
 pub fn fetch_deprecated_simple_icons() -> Vec<IconDeprecation> {
     let tmp_file_name = "simple-icons-deprecated.json";
     let tmp_file_path = Path::new(&env::temp_dir()).join(tmp_file_name);
+    if !tmp_file_path.exists() && is_preview_only_build() {
+        return Vec::new();
+    }
+
     assert!(
         tmp_file_path.exists(),
         "Run `cargo make` to execute the script fetch-deprecated-icons.rs and build."
@@ -46,8 +64,20 @@ pub fn fetch_deprecated_simple_icons() -> Vec<IconDeprecation> {
     .unwrap();
 
     if let Some(message) = resp.get("message") {
-        fs::remove_file(tmp_file_path).unwrap();
+        fs::remove_file(&tmp_file_path).unwrap();
         panic!("Error retrieving data from GITHUB Graphql API: {message}");
+    }
+
+    if resp
+        .get("previewOnly")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or_default()
+        && !is_preview_only_build()
+    {
+        fs::remove_file(&tmp_file_path).unwrap();
+        panic!(
+            "Run `cargo make` to fetch real deprecated icons data and build."
+        );
     }
 
     let milestones_data = resp

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -53,6 +53,26 @@ export const deprecatedIconsFile = path.join(
 	'simple-icons-deprecated.json',
 );
 
+const isPreviewOnlyBuild = () => {
+	const apps = (process.env.APPS ?? '')
+		.split(',')
+		.map((app) => app.trim())
+		.filter(Boolean);
+
+	return apps.length > 0 && apps.every((app) => app === 'preview');
+};
+
+const emptyDeprecatedIconsResponse = {
+	previewOnly: true,
+	data: {
+		repository: {
+			milestones: {
+				nodes: [],
+			},
+		},
+	},
+};
+
 export const fetchDeprecatedIcons = async (
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	onSuccess: () => void = () => {},
@@ -84,6 +104,26 @@ export const fetchDeprecatedIcons = async (
 	}`;
 
 	if (await fileExists(deprecatedIconsFile)) {
+		const deprecatedIconsContent = await fs.readFile(
+			deprecatedIconsFile,
+			'utf8',
+		);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const deprecatedIcons = JSON.parse(deprecatedIconsContent);
+
+		if (!deprecatedIcons.previewOnly || isPreviewOnlyBuild()) {
+			onSuccess();
+			return;
+		}
+
+		await fs.unlink(deprecatedIconsFile);
+	}
+
+	if (isPreviewOnlyBuild()) {
+		await fs.writeFile(
+			deprecatedIconsFile,
+			JSON.stringify(emptyDeprecatedIconsResponse),
+		);
 		onSuccess();
 		return;
 	}

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -53,17 +53,19 @@ export const deprecatedIconsFile = path.join(
 	'simple-icons-deprecated.json',
 );
 
-const isPreviewOnlyBuild = () => {
+const canUseEmptyDeprecatedIcons = () => {
 	const apps = (process.env.APPS ?? '')
 		.split(',')
 		.map((app) => app.trim())
 		.filter(Boolean);
 
-	return apps.length > 0 && apps.every((app) => app === 'preview');
+	return (
+		apps.length > 0 && apps.every((app) => app === 'preview' || app === '404')
+	);
 };
 
 const emptyDeprecatedIconsResponse = {
-	previewOnly: true,
+	emptyDeprecatedIcons: true,
 	data: {
 		repository: {
 			milestones: {
@@ -111,7 +113,10 @@ export const fetchDeprecatedIcons = async (
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const deprecatedIcons = JSON.parse(deprecatedIconsContent);
 
-		if (!deprecatedIcons.previewOnly || isPreviewOnlyBuild()) {
+		if (
+			(!deprecatedIcons.emptyDeprecatedIcons && !deprecatedIcons.previewOnly) ||
+			canUseEmptyDeprecatedIcons()
+		) {
 			onSuccess();
 			return;
 		}
@@ -119,7 +124,7 @@ export const fetchDeprecatedIcons = async (
 		await fs.unlink(deprecatedIconsFile);
 	}
 
-	if (isPreviewOnlyBuild()) {
+	if (canUseEmptyDeprecatedIcons()) {
 		await fs.writeFile(
 			deprecatedIconsFile,
 			JSON.stringify(emptyDeprecatedIconsResponse),


### PR DESCRIPTION
I've adjusted the logic to allow an empty `GITHUB_TOKEN` while building the preview.

This would be friendlier to open-source contributors.